### PR TITLE
ci: build images for arm64 architecture e.g. for new Macs

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,6 +12,7 @@ builds:
     - windows
   goarch:
     - amd64
+    - arm64
   mod_timestamp: '{{ .CommitTimestamp }}'
 archives:
 - name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"


### PR DESCRIPTION
A colleague of mine wants to use the tool on his new M1 Mac book but there was no binary readily available. I had a look how other projects with `goreleaser` [do this](https://github.com/yannh/kubeconform/blob/master/.goreleaser.yml).

It seems unconditionally building an `arm64` flavor for all OSes (Linux can run on that, too) would be the easiest way, but I didn't test it.